### PR TITLE
Add gcc 4.8 so TravisCI can use Node 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,4 @@
 language: node_js
 node_js:
-- '7'
+- 'node'
 services: mongodb
-env:
-  - CXX=g++-4.8
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+cache:
+  bundler: true
+  directories:
+  - node_modules # NPM packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-- 'node'
+- '7.8'
 services: mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,11 @@ language: node_js
 node_js:
 - '7'
 services: mongodb
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,11 @@ language: node_js
 node_js:
 - '7.8'
 services: mongodb
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8


### PR DESCRIPTION
see https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements