### PR TITLE
(fix) 'cannot GET /page' on live reload

### DIFF
--- a/client/store.jsx
+++ b/client/store.jsx
@@ -1,6 +1,6 @@
 import { createStore, compose } from 'redux';
 import { syncHistoryWithStore } from 'react-router-redux';
-import { browserHistory } from 'react-router';
+import { hashHistory } from 'react-router';
 
 import rootReducer from './reducers/index';
 
@@ -19,7 +19,7 @@ const enhancers = compose(
 const store = createStore(rootReducer, defaultState, enhancers);
 console.log('store', store.getState());
 
-export const history = syncHistoryWithStore(browserHistory, store);
+export const history = syncHistoryWithStore(hashHistory, store);
 
 // allows automatic (hot) reloads of changed reducer functions
 if (module.hot) {


### PR DESCRIPTION
**Steps:**

  1. Run `npm run dev:client` or `webpack-dev-server`
  2. Open `http://localhost:8080/`, or whatever webpack serves
  3. Go to `/survey`
  4. Update a component file, like `Main.jsx`

**Expected:** the web page hot reloads the changes

**Actual:** the page reloads, but only says 'cannot GET /survey'

**Fix:** replace `browserHistory` with `hashHistory`