### PR TITLE
(fix) Some client-side routes are broken

### DIFF
--- a/client/store.jsx
+++ b/client/store.jsx
@@ -1,6 +1,6 @@
 import { createStore, compose } from 'redux';
 import { syncHistoryWithStore } from 'react-router-redux';
-import { hashHistory } from 'react-router';
+import { browserHistory } from 'react-router';
 
 import rootReducer from './reducers/index';
 
@@ -21,7 +21,7 @@ const enhancers = compose(
 const store = createStore(rootReducer, defaultState, enhancers);
 console.log('store', store.getState());
 
-export const history = syncHistoryWithStore(hashHistory, store);
+export const history = syncHistoryWithStore(browserHistory, store);
 
 // allows automatic (hot) reloads of changed reducer functions
 if (module.hot) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,11 @@ module.exports = {
     filename: 'bundle.js',
     path: `${__dirname}/public`
   },
-  plugins: [HTMLWebpackPluginConfig,
+  plugins: [
+    HTMLWebpackPluginConfig,
     new webpack.HotModuleReplacementPlugin()
-  ]
+  ],
+  devServer: {
+    historyApiFallback: true
+  }
 };


### PR DESCRIPTION
**Steps to Reproduce:**
1. Run `npm run dev:client`
2. Go `http://localhost:8080/`, or whatever URL that webpack is serving
3. Click on one of the links in the lower left-hand corner

**Expected:**
Go to the selected page

**Actual:**
404 not found

**Fix:**
1. Use `browserHistory` instead of `hashHistory` for react router
2. Turn on `historyApiFallback` for webpack dev server