### PR TITLE
(feature) Webpack Proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:client && npm run test:server",
     "test:client": "mocha-webpack --webpack-config webpack.config-test.babel.js \"client/**/*.test.js\"",
     "test:server": "NODE_ENV=test mocha './server/**/*.test.js'",
-    "dev:client": "webpack-dev-server --progress",
+    "dev:client": "webpack-dev-server --hot --inline --progress",
     "dev:server": "nodemon server/index.js",
     "build": "webpack -p",
     "lint": "eslint ./ --cache --ignore-pattern .gitignore",
@@ -63,7 +63,6 @@
     "socket.io-client": "^1.7.3",
     "url-loader": "^0.5.8",
     "webpack": "^2.3.2",
-    "webpack-node-externals": "^1.5.4",
     "whatwg-fetch": "^2.0.3"
   },
   "devDependencies": {
@@ -73,7 +72,6 @@
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-jsx-a11y": "^4.0.0",
     "eslint-plugin-react": "^6.10.3",
-    "mocha-webpack": "^0.7.0",
     "nodemon": "^1.11.0",
     "pre-commit": "^1.2.2",
     "style-loader": "^0.16.1",

--- a/server/config.js
+++ b/server/config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  port: 8080,
-  database: { uri: 'mongodb://localhost/surveyscribe' },
-  log: './logs/access.log',
-  debug: process.env.NODE_ENV !== 'production'
-};

--- a/server/config/default.json
+++ b/server/config/default.json
@@ -1,5 +1,5 @@
 {
-  "port": 8080,
+  "port": 8000,
   "database": { "uri": "mongodb://localhost/surveyscribe" },
   "public": "./public",
   "log": "./server/logs/access.log",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const HTMLWebpackPlugin = require('html-webpack-plugin');
-const webpack = require('webpack');
 
 const HTMLWebpackPluginConfig = new HTMLWebpackPlugin({
   template: `${__dirname}/client/index.html`,
@@ -41,6 +40,8 @@ module.exports = {
     HTMLWebpackPluginConfig
   ],
   devServer: {
-    historyApiFallback: true
+    historyApiFallback: true,
+    inline: true,
+    hot: true
   }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,4 @@
+const serverConfig = require('./server/helpers/config.js');
 const HTMLWebpackPlugin = require('html-webpack-plugin');
 
 const HTMLWebpackPluginConfig = new HTMLWebpackPlugin({
@@ -41,7 +42,15 @@ module.exports = {
   ],
   devServer: {
     historyApiFallback: true,
-    inline: true,
-    hot: true
+    proxy: {
+      '/api': {
+        target: {
+          host: 'localhost',
+          protocol: 'http',
+          port: serverConfig.port
+        },
+        secure: false
+      }
+    }
   }
 };


### PR DESCRIPTION
Using `webpack-dev-server` cuts down on front-end build times, but doesn't serve live data from a database. Before this update, you could run webpack and an instance of the node server at the same time, but you had to hard-code a URL on the client side. Now you can run both `npm run dev:client` and `npm run dev:server` at the same time and all api requests to the client should be properly forwarded to the server.