### PR TITLE
Bug/surveys

### DIFF
--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -7,25 +7,25 @@ const user = require('../controllers/user.js');
 module.exports = (config) => {
   const router = express.Router();
   router.post('/login', auth.login);
-  router.post('/logout', auth.logout, auth.isLoggedIn);
+  router.post('/logout', auth.isLoggedIn, auth.logout);
 
-  router.route('/api/surveys', auth.isLoggedIn)
-  .get(survey.list)
-  .post(survey.create);
+  router.route('/api/surveys')
+  .get(auth.isLoggedIn, survey.list)
+  .post(auth.isLoggedIn, survey.create);
 
   router.route('/api/surveys/:survey')
   .get(survey.read)
-  .put(survey.update, auth.isLoggedIn)
-  .delete(survey.delete, auth.isLoggedIn);
+  .put(auth.isLoggedIn, survey.update)
+  .delete(auth.isLoggedIn, survey.delete);
 
-  router.route('/api/users', auth.isLoggedIn)
-  .get(user.list)
-  .post(user.create);
+  router.route('/api/users')
+  .get(auth.isLoggedIn, user.list)
+  .post(auth.isLoggedIn, user.create);
 
-  router.route('/api/users/:user', auth.isLoggedIn)
+  router.route('/api/users/:user')
   .get(user.read)
-  .put(user.update, auth.isSameUser)
-  .delete([user.delete, auth.logout], auth.isSameUser);
+  .put(auth.isSameUser, user.update)
+  .delete(auth.isSameUser, [user.delete, auth.logout]);
 
   // 404: Not Found - Unknown route, or MongoDB Couldn't Find Something
   router.use('/api/*', (error, request, response, next) => {

--- a/server/controllers/authentication.js
+++ b/server/controllers/authentication.js
@@ -23,6 +23,7 @@ exports.logout = (request, response) => {
 
 exports.isLoggedIn = (request, response, next) => {
   if (request.session.user) {
+    console.log(request.session.user);
     next();
   } else {
     response.sendStatus(401);

--- a/server/controllers/survey.js
+++ b/server/controllers/survey.js
@@ -1,4 +1,4 @@
-const Survey = require('../models/response.js');
+const Survey = require('../models/survey.js');
 
 exports.list = (request, response, next) => {
   const _id = request.session.user;

--- a/server/tests/controller.response.test.js~Fix schemas
+++ b/server/tests/controller.response.test.js~Fix schemas
@@ -1,0 +1,130 @@
+const chai = require('chai');
+chai.use(require('chai-http'));
+
+const { expect, request } = chai;
+const app = require('../index.js');
+
+xdescribe('Response routes', () => {
+  beforeEach((done) => {
+    Response.remove({}, done); // Empty the database to ensure predictablility
+  });
+  afterEach((done) => {
+    Response.remove({}, done); // Empty the database to ensure predictablility
+  });
+
+  describe('/api/responses', () => {
+    describe('GET', () => {
+      it('should return 200 and all of current user\'s or session\'s responses', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+    });
+
+    describe('POST', () => {
+      it('should return 201 and creates response', () => {
+
+      });
+
+      it('should return 400 if invalid input', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+    });
+
+    describe('PUT', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+
+    describe('PATCH', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+
+    describe('DELETE', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+  });
+
+  describe('/api/responses/:response', () => {
+    describe('GET', () => {
+      it('should return 200 and specified response', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+
+      it('should return 404 if response does not exist', () => {
+
+      });
+    });
+
+    describe('PATCH', () => {
+      it('should return 200 and update part of response', () => {
+
+      });
+
+      it('should return 400 if invalid input', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+    });
+
+    describe('DELETE', () => {
+      it('should return 200 and delete the response', () => {
+
+      });
+
+      it('should return 404 if response does not exist', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+    });
+
+    describe('PUT', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+
+    describe('POST', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+  });
+});

--- a/server/tests/controller.response.test.js~HEAD
+++ b/server/tests/controller.response.test.js~HEAD
@@ -1,0 +1,130 @@
+const chai = require('chai');
+chai.use(require('chai-http'));
+
+const { expect, request } = chai;
+const app = require('../index.js');
+
+xdescribe('Response routes', () => {
+  beforeEach((done) => {
+    Response.remove({}, done); // Empty the database to ensure predictablility
+  });
+  afterEach((done) => {
+    Response.remove({}, done); // Empty the database to ensure predictablility
+  });
+
+  describe('/api/responses', () => {
+    describe('GET', () => {
+      it('should return 200 and all of current user\'s or session\'s responses', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+    });
+
+    describe('POST', () => {
+      it('should return 201 and creates response', () => {
+
+      });
+
+      it('should return 400 if invalid input', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+    });
+
+    describe('PUT', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+
+    describe('PATCH', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+
+    describe('DELETE', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+  });
+
+  describe('/api/responses/:response', () => {
+    describe('GET', () => {
+      it('should return 200 and specified response', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+
+      it('should return 404 if response does not exist', () => {
+
+      });
+    });
+
+    describe('PATCH', () => {
+      it('should return 200 and update part of response', () => {
+
+      });
+
+      it('should return 400 if invalid input', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+    });
+
+    describe('DELETE', () => {
+      it('should return 200 and delete the response', () => {
+
+      });
+
+      it('should return 404 if response does not exist', () => {
+
+      });
+
+      it('should return 401 if user\'s not authenticated', () => {
+
+      });
+
+      it('should return 401 if user\'s not the owner', () => {
+
+      });
+    });
+
+    describe('PUT', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+
+    describe('POST', () => {
+      it('should return 405 METHOD NOT ALLOWED', () => {
+
+      });
+    });
+  });
+});

--- a/server/tests/model.user.test.js
+++ b/server/tests/model.user.test.js
@@ -27,9 +27,15 @@ describe('User Model', () => {
     });
   });
 
+<<<<<<< HEAD
   describe('.verifyPassword', () => {
     it('is a function', () => {
       expect(User.schema.methods.verifyPassword).to.be.function;
+=======
+  describe('.authenticate', () => {
+    it('is a function', () => {
+      expect(User.schema.methods.authenticate).to.be.function;
+>>>>>>> Fix schemas
     });
 
     it('returns true if the password matches and false if it doesn\'t', (done) => {
@@ -38,8 +44,13 @@ describe('User Model', () => {
       User.create(expected)
       .then(user => User.findById(user._id, 'name hash').exec())
       .then((user) => {
+<<<<<<< HEAD
         expect(user.verifyPassword(expected.password)).to.be.true;
         expect(user.verifyPassword(mistmatch)).to.be.false;
+=======
+        expect(user.authenticate(expected.password)).to.be.true;
+        expect(user.authenticate(mistmatch)).to.be.false;
+>>>>>>> Fix schemas
         done();
       })
       .catch(done); // immediately output errors instead of timing out
@@ -58,7 +69,11 @@ describe('User Model', () => {
         expect(user.password).to.be.undefined;
         expect(user.hash).to.exist;
         expect(Buffer.isBuffer(user.hash)).to.be.true;
+<<<<<<< HEAD
         expect(user.verifyPassword(expected.password, user.hash));
+=======
+        expect(user.authenticate(expected.password, user.hash));
+>>>>>>> Fix schemas
         done();
       })
       .catch(done); // immediately output errors instead of timing out

--- a/server/tests/model.user.test.js
+++ b/server/tests/model.user.test.js
@@ -27,21 +27,9 @@ describe('User Model', () => {
     });
   });
 
-<<<<<<< HEAD
-<<<<<<< HEAD
   describe('.verifyPassword', () => {
     it('is a function', () => {
       expect(User.schema.methods.verifyPassword).to.be.function;
-=======
-  describe('.authenticate', () => {
-    it('is a function', () => {
-      expect(User.schema.methods.authenticate).to.be.function;
->>>>>>> Fix schemas
-=======
-  describe('.verifyPassword', () => {
-    it('is a function', () => {
-      expect(User.schema.methods.verifyPassword).to.be.function;
->>>>>>> (fix) User test refers to an old function name
     });
 
     it('returns true if the password matches and false if it doesn\'t', (done) => {
@@ -50,18 +38,8 @@ describe('User Model', () => {
       User.create(expected)
       .then(user => User.findById(user._id, 'name hash').exec())
       .then((user) => {
-<<<<<<< HEAD
-<<<<<<< HEAD
         expect(user.verifyPassword(expected.password)).to.be.true;
         expect(user.verifyPassword(mistmatch)).to.be.false;
-=======
-        expect(user.authenticate(expected.password)).to.be.true;
-        expect(user.authenticate(mistmatch)).to.be.false;
->>>>>>> Fix schemas
-=======
-        expect(user.verifyPassword(expected.password)).to.be.true;
-        expect(user.verifyPassword(mistmatch)).to.be.false;
->>>>>>> (fix) User test refers to an old function name
         done();
       })
       .catch(done); // immediately output errors instead of timing out
@@ -80,15 +58,7 @@ describe('User Model', () => {
         expect(user.password).to.be.undefined;
         expect(user.hash).to.exist;
         expect(Buffer.isBuffer(user.hash)).to.be.true;
-<<<<<<< HEAD
-<<<<<<< HEAD
         expect(user.verifyPassword(expected.password, user.hash));
-=======
-        expect(user.authenticate(expected.password, user.hash));
->>>>>>> Fix schemas
-=======
-        expect(user.verifyPassword(expected.password, user.hash));
->>>>>>> (fix) User test refers to an old function name
         done();
       })
       .catch(done); // immediately output errors instead of timing out

--- a/server/tests/model.user.test.js
+++ b/server/tests/model.user.test.js
@@ -28,6 +28,7 @@ describe('User Model', () => {
   });
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   describe('.verifyPassword', () => {
     it('is a function', () => {
       expect(User.schema.methods.verifyPassword).to.be.function;
@@ -36,6 +37,11 @@ describe('User Model', () => {
     it('is a function', () => {
       expect(User.schema.methods.authenticate).to.be.function;
 >>>>>>> Fix schemas
+=======
+  describe('.verifyPassword', () => {
+    it('is a function', () => {
+      expect(User.schema.methods.verifyPassword).to.be.function;
+>>>>>>> (fix) User test refers to an old function name
     });
 
     it('returns true if the password matches and false if it doesn\'t', (done) => {
@@ -45,12 +51,17 @@ describe('User Model', () => {
       .then(user => User.findById(user._id, 'name hash').exec())
       .then((user) => {
 <<<<<<< HEAD
+<<<<<<< HEAD
         expect(user.verifyPassword(expected.password)).to.be.true;
         expect(user.verifyPassword(mistmatch)).to.be.false;
 =======
         expect(user.authenticate(expected.password)).to.be.true;
         expect(user.authenticate(mistmatch)).to.be.false;
 >>>>>>> Fix schemas
+=======
+        expect(user.verifyPassword(expected.password)).to.be.true;
+        expect(user.verifyPassword(mistmatch)).to.be.false;
+>>>>>>> (fix) User test refers to an old function name
         done();
       })
       .catch(done); // immediately output errors instead of timing out
@@ -70,10 +81,14 @@ describe('User Model', () => {
         expect(user.hash).to.exist;
         expect(Buffer.isBuffer(user.hash)).to.be.true;
 <<<<<<< HEAD
+<<<<<<< HEAD
         expect(user.verifyPassword(expected.password, user.hash));
 =======
         expect(user.authenticate(expected.password, user.hash));
 >>>>>>> Fix schemas
+=======
+        expect(user.verifyPassword(expected.password, user.hash));
+>>>>>>> (fix) User test refers to an old function name
         done();
       })
       .catch(done); // immediately output errors instead of timing out


### PR DESCRIPTION
- (fix) User test refers to an old function name
- (fix) Survey routes return results
- (fix) Unauthenticated users can view authenticated routes

NOTE: `participant` is intentionally in the `response` schema, but (intentionally) shouldn't show up in the API.