### PR TITLE
Replace default mongoDB IDs with URL-safe IDs.

### DIFF
--- a/client/actions/actionCreators.js
+++ b/client/actions/actionCreators.js
@@ -1,4 +1,4 @@
-import { Types } from 'mongoose';
+import { generate as ObjectId } from 'shortid';
 
 // update state
 export function updateState(surveys, questions, options) {
@@ -40,7 +40,7 @@ export function addQuestion(surveyId, questionType) {
   return {
     type: 'ADD_QUESTION',
     surveyId,
-    id: Types.ObjectId(),
+    id: ObjectId(),
     questionType
   };
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-tap-event-plugin": "^2.0.1",
     "redux": "^3.6.0",
     "request": "^2.81.0",
+    "shortid": "^2.2.8",
     "socket.io": "^1.7.3",
     "socket.io-client": "^1.7.3",
     "sodium": "^2.0.1",

--- a/server/controllers/survey.js
+++ b/server/controllers/survey.js
@@ -2,7 +2,7 @@ const Survey = require('../models/survey.js');
 
 exports.list = (request, response, next) => {
   const _id = request.session.user;
-  Survey.find({ owners: { $in: [_id] } }).exec()
+  Survey.find({ owners: { $in: [_id] } }, '_id title').exec()
     .then((data) => { response.status(200).json(data); })
     .catch(next);
 };

--- a/server/models/id.js
+++ b/server/models/id.js
@@ -1,0 +1,10 @@
+const shortid = require('shortid');
+
+exports.schema = {
+  type: String,
+  default: shortid.generate
+};
+
+// Syntactic Sugar
+exports._id = exports.schema;
+exports.ObjectId = exports.schema.type;

--- a/server/models/response.js
+++ b/server/models/response.js
@@ -1,13 +1,15 @@
 const mongoose = require('mongoose');
+const { _id, ObjectId } = require('./id.js');
 
 const Schema = mongoose.Schema;
-const ObjectId = Schema.Types.ObjectId;
 
 const AnswerSchema = Schema({
+  _id,
   question: { type: ObjectId, ref: 'Survey.questions' }
 }, { discriminatorKey: 'kind' });
 
 const ResponseSchema = Schema({
+  _id,
   participant: { type: String, ref: 'Session.sid', select: false },
     /* /!\ DANGER /!\
      * The 'participant' field stores a sessionID. Be careful how you handle

--- a/server/models/survey.js
+++ b/server/models/survey.js
@@ -1,14 +1,16 @@
 const mongoose = require('mongoose');
+const { _id, ObjectId } = require('./id.js');
 
 const Schema = mongoose.Schema;
-const ObjectId = Schema.Types.ObjectId;
 
 const QuestionSchema = Schema({
+  _id,
   title: String,
   required: Boolean
 }, { discriminatorKey: 'kind' });
 
 const SurveySchema = Schema({
+  _id,
   title: String,
   owners: [{ type: ObjectId, ref: 'User' }],
   questions: [QuestionSchema]
@@ -17,7 +19,7 @@ const SurveySchema = Schema({
 const Questions = SurveySchema.path('questions');
 
 Questions.discriminator('Select', Schema({
-  options: [{ label: String }],
+  options: [{ _id, label: String }],
   maxSelection: Number
 }));
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,10 +1,12 @@
 const assert = require('assert');
-const mongoose = require('mongoose');
 const sodium = require('sodium').api;
+const mongoose = require('mongoose');
+const { _id } = require('./id.js');
 
 const Schema = mongoose.Schema;
 
 const UserSchema = Schema({
+  _id,
   name: { type: String, required: true, index: { unique: true } },
   hash: { type: String, required: true, select: false }
 });


### PR DESCRIPTION
The default IDs are predictable, which makes them unsafe to use in URLs, time-based, which invites collisions when multiple computers are generating IDs, and really long, which creates awkwardly long URLs.

CAUTION: Merge #163 first.